### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -17,7 +17,7 @@ license = "CC0-1.0"
 [dependencies]
 
 [dev-dependencies]
-version-sync = "0.7"
+version-sync = "0.8"
 
 
 # cargo-release configuration


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.